### PR TITLE
add fzf example script with only unique lines and previews

### DIFF
--- a/contrib/cliphist-fzf
+++ b/contrib/cliphist-fzf
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Outputs only unique lines and shows preview for the highlighted non-binary item
+
+case "$1" in
+	preview)
+		# show preview if non-binary data
+		echo "$2" | grep -q '^[[:digit:]]*\. binary data' || echo "$2" | cliphist decode
+		;;
+	*)
+		exec cliphist list |
+			sort -k 2 -u | # sort by 2 field to the end of line and output only unique lines
+			sort -nr |     # sort numerically in reverse
+			fzf --preview "$(realpath "$0") preview {}" |
+			cliphist decode |
+			wl-copy
+		;;
+esac


### PR DESCRIPTION
Thanks for a nice clipboard manager! Switched from clipman.

Thought you might be interested in adding a contrib folder with an example fzf
implementation: it only lists unique lines and shows a preview for the
highlighted item.

If not -- feel free to close.
