### PR TITLE
FEAT: max length option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ page](https://github.com/sentriz/cliphist/releases)
 `$ wl-paste --watch cliphist store`  
 this will listen for changes on your primary keyboard and write it to
 the history.  
-call it once per session - for example in your sway config
+call it once per session - for example in your sway config  
 or else with a maximum history length of 100 (defaults to 750)
 `$ wl-paste --watch cliphist store --max-len 100`  
 

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,8 @@ page](https://github.com/sentriz/cliphist/releases)
 this will listen for changes on your primary keyboard and write it to
 the history.  
 call it once per session - for example in your sway config
+or else with a maximum history length of 100 (defaults to 750)
+`$ wl-paste --watch cliphist store --max-len 100`  
 
 ###### select old item
 


### PR DESCRIPTION
This PR adds the ability to specify a custom max history length.

`cliphist store --max-len 10` cuts the history length at 10. (Only 10 entries are left in the entire history, the rest is cleared)

`cliphist store` is not affected by this, and retains the default max length of 750, which was hard coded before.