### PR TITLE
cmd name is at index 0, not 1

### DIFF
--- a/cliphist.go
+++ b/cliphist.go
@@ -40,7 +40,7 @@ func main() {
 		os.Exit(1)
 	}
 	if err := cmd(flag.Args()[1:]); err != nil {
-		fmt.Fprintf(os.Stderr, "error in %q: %v", flag.Args()[1], err)
+		fmt.Fprintf(os.Stderr, "error in %q: %v", flag.Args()[0], err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This is a trivial fix. I tested cliphist with bemenu, cancelled the menu selection, and got a runtime error like:

```
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
main.main()
        /work/tmp/cliphist/cliphist.go:43 +0x20c
```

This will also happen if you just do a `cliphist decode` and then close stdin (^D).

It seems that the error message wants to reference the sub-command that was executed, but tries to get it from index 1 of Args(), when it is actually in index 0. Since this index is already referenced a few lines above, I did not add any error checking.