### PR TITLE
Add wofi example that handles quotes correctly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,9 @@ cliphist list | rofi -dmenu -display-columns 2 | cliphist decode | wl-copy
 ```shell
 # wofi
 # it kind of works but breaks with quotes in the original selection. i recommend not trying to hide the column with wofi
-cliphist list | wofi --dmenu --pre-display-cmd "echo '%s' | cut -f 2" | cliphist decode | wl-copy
+cliphist list | wofi --dmenu --pre-display-cmd "echo -n '%s' | cut -z -f 2" | cliphist decode | wl-copy
+# if you want to try anyway, this should handle quotes correctly
+cliphist list | xargs -d "\n" printf "%q\n" | wofi --dmenu --pre-display-cmd "echo -n %s | cut -z -f 2" | xargs -0 -I {} bash -c "echo {}" | cliphist decode | wl-copy
 ```
 
 </details>


### PR DESCRIPTION
The example for removing the id number of history items for wofi doesn't handle quotes correctly. I added a snippet that does (I hope).

It's *very* cursed. I am sorry.

A short explanation taken from my dotfiles I wrote for myself so I don't forget:

"The gist is: the %q in printf quotes the string in a shell-compatible way. Thanks to that, we can put in --pre-display-cmd with %s in wofi, and the string will be correctly interpreted there, even if it contains quotes or stuff itself.

The pre-display-cmd is there for removing the leading ID number (separated by tab) in the history item string so it isn't displayed, but not removed from the actual string passed back to cliphist. See https://github.com/sentriz/cliphist#faq

Using xargs, we give the quoted string to bash, which then interprets the quotes, and echo out the unquoted string, which we can then finally pass back to cliphist."

I've also added `-n` to the echo call so it doesn't emit a newline, and `-z` to the `cut` call for the same reason. Without it, wofi was showing each entry on two lines for me.

see also my dotfiles: https://git.eisfunke.com/config/nixos/-/commit/d726ba6a3a22d7d7ae445c6ac95b7670c73a451c