### PR TITLE
Add rofi script with support for displaying images

### DIFF
--- a/contrib/cliphist-rofi-img
+++ b/contrib/cliphist-rofi-img
@@ -3,20 +3,25 @@
 tmp_dir="/tmp/cliphist"
 rm -rf "$tmp_dir"
 
-if [ -z "$1" ]; then
-	mkdir -p "$tmp_dir"
-	# When an image is copied from Firefox, some garbage text gets added to the clipboard too. We exclude that
-	cliphist list | grep -E -v '<meta http-equiv="content-type" content="text/html; charset=utf-8"><img' | \
-		while read data; do
-			echo "$data" | grep 'binary data image' &>/dev/null
-			if [ "$?" -eq 0 ] ; then
-				fname="$(echo "$data" | cut -f1)"
-				cliphist decode <<< "$data" >| "$tmp_dir"/"$fname".png &
-				echo -en "$data\0icon\x1f$tmp_dir/$fname.png\n"
-			else
-				echo "$data"
-			fi
-		done
-else
+if [[ -n "$1" ]]; then
 	cliphist decode <<<"$1" | wl-copy
+	exit
 fi
+
+mkdir -p "$tmp_dir"
+
+cliphist list \
+	| grep -Fv '<meta http-equiv="content-type"' \
+	| while read -r data; do
+	fname="$(cut -f1 <<<"$data")"
+	fext="$(cut -f2 <<<"$data" | cut -d ' ' -f6)"
+	case "$fext" in
+		jpg|jpeg|png|bmp)
+			cliphist decode <<<"$data" >|"$tmp_dir"/"$fname"."$fext" &
+			echo -en "$data\0icon\x1f$tmp_dir/$fname.$fext\n"
+			;;
+		*)
+			echo "$data"
+			;;
+	esac
+done

--- a/contrib/cliphist-rofi-img
+++ b/contrib/cliphist-rofi-img
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+tmp_dir="/tmp/cliphist"
+rm -rf "$tmp_dir"
+
+if [ -z "$1" ]; then
+	mkdir -p "$tmp_dir"
+	# When an image is copied from Firefox, some garbage text gets added to the clipboard too. We exclude that
+	cliphist list | grep -E -v '<meta http-equiv="content-type" content="text/html; charset=utf-8"><img' | \
+		while read data; do
+			echo "$data" | grep 'binary data image' &>/dev/null
+			if [ "$?" -eq 0 ] ; then
+				fname="$(echo "$data" | cut -f1)"
+				cliphist decode <<< "$data" >| "$tmp_dir"/"$fname".png &
+				echo -en "$data\0icon\x1f$tmp_dir/$fname.png\n"
+			else
+				echo "$data"
+			fi
+		done
+else
+	cliphist decode <<<"$1" | wl-copy
+fi

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,12 @@ or else query manually
 
 </details>
 
+<summary>rofi (displays images)</summary>
+
+`rofi -modi clipboard:/path/to/cliphist-rofi-img -show clipboard -show-icons` with [contrib/cliphist-rofi-img](https://github.com/sentriz/cliphist/blob/master/contrib/cliphist-rofi-img)
+
+</details>
+
 <details>
 <summary>rofi dmenu mode</summary>
 


### PR DESCRIPTION
![image](https://github.com/sentriz/cliphist/assets/61394886/c502e497-0b10-40fe-bc89-a795a258cabe)

The script is a modified version of #43. It writes each image in the clipboard to a file and then displays it in rofi. It also appends "png" to each file name because rofi wouldn't try to open the image otherwise.
While I would love to avoid writing the files to disk, it doesn't seem to be possible due to the way rofi tries to open the image files. I also chose to write them to /tmp in order to avoid unnecessary drive wear and make the write operations a bit faster (it's instant in my experience anyways, even with multiple large images).