### PR TITLE
Contrib wofi image

### DIFF
--- a/contrib/cliphist-wofi-img
+++ b/contrib/cliphist-wofi-img
@@ -7,7 +7,7 @@
 # produces thumbnails and stores them in XDG_CACHE_HOME
 # note: does NOT put in clipboard, call wl-copy yourself!
 
-# setup thumbnail directory, clear this manually periodically
+# set up thumbnail directory
 thumb_dir="${XDG_CACHE_HOME:-$HOME/.cache}/cliphist/thumbs"
 mkdir -p "$thumb_dir"
 

--- a/contrib/cliphist-wofi-img
+++ b/contrib/cliphist-wofi-img
@@ -11,6 +11,18 @@
 thumb_dir="${XDG_CACHE_HOME:-$HOME/.cache}/cliphist/thumbs"
 mkdir -p "$thumb_dir"
 
+cliphist_list="$(cliphist list)"
+
+# delete thumbnails in cache but not in cliphist
+for thumb in "$thumb_dir"/*; do
+    clip_id="${thumb##*/}"
+    clip_id="${clip_id%.*}"
+    check=$(rg <<< "$cliphist_list" "^$clip_id\s")
+    if [ -z "$check" ]; then
+        >&2 rm -v "$thumb"
+    fi
+done
+
 # remove unnecessary image tags
 # create thumbnail if image not processed already
 # print escape sequence
@@ -25,7 +37,7 @@ match(\$0, /^([0-9]+)\s(\[\[\s)?binary.*(jpg|jpeg|png|bmp)/, grp) {
 1
 EOF
 
-choice="$(cliphist list | gawk "$prog" | wofi -I --dmenu)"
+choice=$(gawk <<< $cliphist_list "$prog" | wofi -I --dmenu)
 
 # stop execution if nothing selected in wofi menu
 [ -z "$choice" ] && exit 1

--- a/contrib/cliphist-wofi-img
+++ b/contrib/cliphist-wofi-img
@@ -1,0 +1,41 @@
+#!/usr/bin/bash
+
+# executes same behaviour as below but with support for images
+#
+# cliphist list | wofi --dmenu | cliphist decode
+#
+# produces thumbnails and stores them in XDG_CACHE_HOME
+# note: does NOT put in clipboard, call wl-copy yourself!
+
+# setup thumbnail directory, clear this manually periodically
+thumb_dir="${XDG_CACHE_HOME:-$HOME/.cache}/cliphist/thumbs"
+mkdir -p "$thumb_dir"
+
+# remove unnecessary image tags
+# create thumbnail if image not processed already
+# print escape sequence
+read -r -d '' prog <<EOF
+/^[0-9]+\s<meta http-equiv=/ { next }
+match(\$0, /^([0-9]+)\s(\[\[\s)?binary.*(jpg|jpeg|png|bmp)/, grp) {
+    image = grp[1]"."grp[3]
+    system("[ -f $thumb_dir/"image" ] || echo " grp[1] "\\\\\t | cliphist decode | convert - -resize '256x256>' $thumb_dir/"image )
+    print "img:$thumb_dir/"image
+    next
+}
+1
+EOF
+
+choice="$(cliphist list | gawk "$prog" | wofi -I --dmenu)"
+
+# stop execution if nothing selected in wofi menu
+[ -z "$choice" ] && exit 1
+
+if [ "${choice::4}" = "img:" ]; then
+    thumb_file="${choice:4}"
+    clip_id="${thumb_file##*/}"
+    clip_id="${clip_id%.*}\t"
+else
+    clip_id="${choice}"
+fi
+
+printf "$clip_id" | cliphist decode


### PR DESCRIPTION
The script I use to manage my clipboard history with wofi, with image support.

Wofi escapes images with the format `"img:/path/to/image"` with the `-I` flag enabled. Thumbnails of the images are cached as loading the full resolutions was adding a bit too long a delay in opening wofi (in the order of up to a few seconds for a couple of 1080p clip entries on my machine). Ideally the thumbnails would be removed when pushed out of the clipboard, and not on a subsequent call to the script as is, but this would require one of:
- cliphist managing thumbnails (IMO not necessary and a little feature-creepy)
- adding a callback script that gets called for each removed entry (IMO not worth the effort)

I'm fine with it as is.

![image](https://github.com/sentriz/cliphist/assets/70713580/6431f94d-ac2c-41bc-8dcb-4d62e208999a)

(please excuse the poor sizing and style, I've not gotten around styling wofi yet, but the functionality is there!)
