### PR TITLE
contrib/cliphist-wofi-img: Resize images to make them clearly visible

### DIFF
--- a/contrib/cliphist-wofi-img
+++ b/contrib/cliphist-wofi-img
@@ -37,7 +37,7 @@ match(\$0, /^([0-9]+)\s(\[\[\s)?binary.*(jpg|jpeg|png|bmp)/, grp) {
 1
 EOF
 
-choice=$(gawk <<< $cliphist_list "$prog" | wofi -I --dmenu)
+choice=$(gawk <<< $cliphist_list "$prog" | wofi -I --dmenu -Dimage_size=100 -Dynamic_lines=true)
 
 # stop execution if nothing selected in wofi menu
 [ -z "$choice" ] && exit 1


### PR DESCRIPTION
"-Dimage_size=100" to increase image size.
"-Dynamic_lines=true" to allow the height of the images to be different from the text height.
![image](https://github.com/sentriz/cliphist/assets/121488032/26592d13-f806-494a-ae09-fcfcf27abbd6)

Thanks to  @scientiac in https://github.com/sentriz/cliphist/issues/85#issuecomment-2106121346_
