### PR TITLE
feat(contrib): cliphist-fuzzel-img drop imagemagick

### DIFF
--- a/contrib/cliphist-fuzzel-img
+++ b/contrib/cliphist-fuzzel-img
@@ -1,27 +1,24 @@
 #!/usr/bin/env bash
 
-# requires imagemagick to generate thumbnails
-
-thumbnail_size=64
 thumbnail_dir="${XDG_CACHE_HOME:-$HOME/.cache}/cliphist/thumbnails"
 
 cliphist_list=$(cliphist list)
 if [ -z "$cliphist_list" ]; then
-  fuzzel -d --placeholder "cliphist: please store something first" --lines 0
+  fuzzel -d --prompt-only "cliphist: please store something first "
   rm -rf "$thumbnail_dir"
   exit
 fi
 
 [ -d "$thumbnail_dir" ] || mkdir -p "$thumbnail_dir"
 
-# Write square shaped thumbnail to cache if it doesn't exist
+# Write binary image to cache file if it doesn't exist
 read -r -d '' thumbnail <<EOF
 /^[0-9]+\s<meta http-equiv=/ { next }
 match(\$0, /^([0-9]+)\s(\[\[\s)?binary.*(jpg|jpeg|png|bmp)/, grp) {
   cliphist_item_id=grp[1]
   ext=grp[3]
   thumbnail_file=cliphist_item_id"."ext
-  system("[ -f ${thumbnail_dir}/"thumbnail_file" ] || echo " cliphist_item_id "\\\\\t | cliphist decode | magick - -thumbnail ${thumbnail_size}^ -gravity center -extent ${thumbnail_size} ${thumbnail_dir}/"thumbnail_file)
+  system("[ -f ${thumbnail_dir}/"thumbnail_file" ] || echo " cliphist_item_id "\\\\\t | cliphist decode >${thumbnail_dir}/"thumbnail_file)
   print \$0"\0icon\x1f${thumbnail_dir}/"thumbnail_file
   next
 }


### PR DESCRIPTION
as promised in https://github.com/sentriz/cliphist/pull/144#issuecomment-2875984510

before (fuzzel 1.12, imagemagick squired):

<img width="452" height="60" alt="2025-08-20_10-04-19" src="https://github.com/user-attachments/assets/b5ee0169-1eb5-4a98-84e8-c4ba877422f9" />

after (fuzzel 1.13, no imagemagick needed)

<img width="448" height="46" alt="2025-08-20_10-04-39" src="https://github.com/user-attachments/assets/b9b799c9-8246-4980-9869-bb3d31570558" />

![](https://repology.org/badge/vertical-allrepos/fuzzel.svg?columns=4)
