### PR TITLE
Update wofi command

### DIFF
--- a/contrib/cliphist-wofi-img
+++ b/contrib/cliphist-wofi-img
@@ -37,7 +37,7 @@ match(\$0, /^([0-9]+)\s(\[\[\s)?binary.*(jpg|jpeg|png|bmp)/, grp) {
 1
 EOF
 
-choice=$(gawk <<< $cliphist_list "$prog" | wofi -I --dmenu -Dimage_size=100 -Dynamic_lines=true)
+choice=$(gawk <<< $cliphist_list "$prog" | wofi -I --dmenu --cache-file=/dev/null -Dimage_size=100 -Dynamic_lines=true)
 
 # stop execution if nothing selected in wofi menu
 [ -z "$choice" ] && exit 1


### PR DESCRIPTION
Update the wofi startup command to disable the cache. In this case, sorting by popularity is very disruptive. The “--cache-file=/dev/null” flag returns the “latest options above” sorting.