### PR TITLE
fix: min-store-length sets max length instead of min

### DIFF
--- a/cliphist.go
+++ b/cliphist.go
@@ -107,7 +107,7 @@ func store(dbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLen
 	if len(input) > 5*1e6 { // don't store >5MB
 		return nil
 	}
-	if int(minLength) > 0 && graphemeClusterCount(string(input)) > int(minLength) {
+	if int(minLength) > 0 && graphemeClusterCount(string(input)) < int(minLength) {
 		return nil
 	}
 

--- a/testdata/min-store-length.txtar
+++ b/testdata/min-store-length.txtar
@@ -16,4 +16,4 @@ exec cliphist -min-store-length 3 store
 
 # we didn't store the last, 4 > 3
 exec cliphist list
-stdout -count=2 '^.'
+stdout -count=3 '^.'

--- a/testdata/min-store-length.txtar
+++ b/testdata/min-store-length.txtar
@@ -14,6 +14,22 @@ exec randstr 4
 stdin stdout
 exec cliphist -min-store-length 3 store
 
-# we didn't store the last, 4 > 3
+# we can store the last, since 4 > 3
 exec cliphist list
 stdout -count=3 '^.'
+
+exec randstr 2
+stdin stdout
+exec cliphist -min-store-length 3 store
+
+# not the last, since 4 > 3
+exec cliphist list
+stdout -count=3 '^.'
+
+exec randstr 3
+stdin stdout
+exec cliphist -min-store-length 3 store
+
+# last is fine, 3 == 3
+exec cliphist list
+stdout -count=4 '^.'


### PR DESCRIPTION
current logic allowed only for results shorter than min length instead of longer