### PR TITLE
Add configurable max clipboard size with `-max-size` flag

### DIFF
--- a/cliphist.go
+++ b/cliphist.go
@@ -58,12 +58,19 @@ func main() {
 	maxDedupeSearch := flag.Uint64("max-dedupe-search", 100, "maximum number of last items to look through when finding duplicates")
 	minLength := flag.Uint("min-store-length", 0, "minimum number of characters to store")
 	previewWidth := flag.Uint("preview-width", 100, "maximum number of characters to preview")
+	maxSizeStr := flag.String("max-size", "5MB", "maximum size of clipboard to store (e.g., 5MB, 10MiB, 1GB)")
 	dbPath := flag.String("db-path", filepath.Join(cacheHome, "cliphist", "db"), "path to db")
 	configPath := flag.String("config-path", filepath.Join(configHome, "cliphist", "config"), "overwrite config path to use instead of cli flags")
 
 	flag.Parse()
 	flagconf.ParseEnv()
 	flagconf.ParseConfig(*configPath)
+
+	maxSize, err := parseSize(*maxSizeStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid max-size value: %v\n", err)
+		os.Exit(1)
+	}
 
 	switch flag.Arg(0) {
 	case "store":
@@ -72,7 +79,7 @@ func main() {
 		case "clear":
 			err = deleteLast(*dbPath)
 		default:
-			err = store(*dbPath, os.Stdin, *maxDedupeSearch, *maxItems, *minLength)
+			err = store(*dbPath, os.Stdin, *maxDedupeSearch, *maxItems, *minLength, maxSize)
 		}
 	case "list":
 		err = list(*dbPath, os.Stdout, *previewWidth)
@@ -99,12 +106,12 @@ func main() {
 	}
 }
 
-func store(dbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLength uint) error {
+func store(dbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLength uint, maxSize uint64) error {
 	input, err := io.ReadAll(in)
 	if err != nil {
 		return fmt.Errorf("read stdin: %w", err)
 	}
-	if len(input) > 5*1e6 { // don't store >5MB
+	if maxSize > 0 && uint64(len(input)) > maxSize {
 		return nil
 	}
 	if int(minLength) > 0 && graphemeClusterCount(string(input)) < int(minLength) {
@@ -507,4 +514,50 @@ func sizeStr(size int) string {
 		i++
 	}
 	return fmt.Sprintf("%.0f %s", fsize, units[i])
+}
+
+// parseSize parses a size string like "5MB", "10MiB", "1024" into bytes
+func parseSize(s string) (uint64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty size string")
+	}
+
+	// Ordered from longest to shortest suffix to avoid partial matches
+	units := []struct {
+		suffix     string
+		multiplier uint64
+	}{
+		{"gib", 1024 * 1024 * 1024},
+		{"mib", 1024 * 1024},
+		{"kib", 1024},
+		{"gb", 1000 * 1000 * 1000},
+		{"mb", 1000 * 1000},
+		{"kb", 1000},
+		{"b", 1},
+	}
+
+	lower := strings.ToLower(s)
+
+	for _, unit := range units {
+		if strings.HasSuffix(lower, unit.suffix) {
+			numStr := s[:len(s)-len(unit.suffix)]
+			numStr = strings.TrimSpace(numStr)
+			num, err := strconv.ParseFloat(numStr, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid number: %w", err)
+			}
+			if num < 0 {
+				return 0, fmt.Errorf("size cannot be negative")
+			}
+			return uint64(num * float64(unit.multiplier)), nil
+		}
+	}
+
+	// No unit suffix, treat as bytes
+	num, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size: %w", err)
+	}
+	return num, nil
 }

--- a/cliphist_test.go
+++ b/cliphist_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/rand"
 	"fmt"
 	"image"
@@ -10,6 +11,7 @@ import (
 	"io"
 	mathrand "math/rand"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -46,6 +48,134 @@ func TestMain(m *testing.M) {
 		"bmp":  func() int { _ = bmp.Encode(os.Stdout, testImage); return 0 },
 		"tiff": func() int { _ = tiff.Encode(os.Stdout, testImage, nil); return 0 },
 	}))
+}
+
+func TestStoreMaxSize(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputSize   int
+		maxSize     uint64
+		shouldStore bool
+	}{
+		// Under limit: should store
+		{"under limit", 100, 1000, true},
+		{"exactly at limit", 1000, 1000, true},
+
+		// Over limit: should not store
+		{"over limit by 1", 1001, 1000, false},
+		{"way over limit", 5000, 1000, false},
+
+		// maxSize 0 = no limit
+		{"no limit small", 100, 0, true},
+		{"no limit large", 100000, 0, true},
+
+		// Test with realistic sizes
+		{"5MB limit under", 4 * 1024 * 1024, 5 * 1000 * 1000, true},
+		{"5MB limit over", 6 * 1024 * 1024, 5 * 1000 * 1000, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary db
+			tmpDir, err := os.MkdirTemp("", "cliphist-test-*")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer func() { _ = os.RemoveAll(tmpDir) }()
+
+			dbPath := filepath.Join(tmpDir, "db")
+
+			// Generate input of specified size
+			input := make([]byte, tt.inputSize)
+			for i := range input {
+				input[i] = 'a'
+			}
+
+			// Execute store
+			err = store(dbPath, bytes.NewReader(input), 100, 750, 0, tt.maxSize)
+			if err != nil {
+				t.Fatalf("store failed: %v", err)
+			}
+
+			// Verify if it was stored
+			var output bytes.Buffer
+			err = list(dbPath, &output, 100)
+
+			if tt.shouldStore {
+				if err != nil {
+					t.Fatalf("list failed: %v", err)
+				}
+				if output.Len() == 0 {
+					t.Errorf("expected item to be stored, but list is empty")
+				}
+			} else {
+				// If it shouldn't store, list might fail (db doesn't exist) or return empty
+				if err == nil && output.Len() > 0 {
+					t.Errorf("expected item NOT to be stored, but list returned: %s", output.String())
+				}
+			}
+		})
+	}
+}
+
+func TestParseSize(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected uint64
+		wantErr  bool
+	}{
+		// Bytes without unit
+		{"0", 0, false},
+		{"1024", 1024, false},
+		{"5000000", 5000000, false},
+
+		// Decimal units (base 1000)
+		{"1KB", 1000, false},
+		{"5MB", 5 * 1000 * 1000, false},
+		{"1GB", 1000 * 1000 * 1000, false},
+		{"2.5MB", 2500000, false},
+
+		// Binary units (base 1024)
+		{"1KiB", 1024, false},
+		{"5MiB", 5 * 1024 * 1024, false},
+		{"1GiB", 1024 * 1024 * 1024, false},
+		{"2.5MiB", uint64(2.5 * 1024 * 1024), false},
+
+		// Case insensitive
+		{"5mb", 5 * 1000 * 1000, false},
+		{"5Mb", 5 * 1000 * 1000, false},
+		{"5mib", 5 * 1024 * 1024, false},
+		{"5MIB", 5 * 1024 * 1024, false},
+
+		// With spaces
+		{" 5MB ", 5 * 1000 * 1000, false},
+		{"5 MB", 5 * 1000 * 1000, false},
+
+		// Errors
+		{"", 0, true},
+		{"abc", 0, true},
+		{"MB", 0, true},
+		{"-5MB", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := parseSize(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseSize(%q) expected error, got %d", tt.input, result)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseSize(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("parseSize(%q) = %d, want %d", tt.input, result, tt.expected)
+			}
+		})
+	}
 }
 
 func TestScripts(t *testing.T) {


### PR DESCRIPTION
## Pull Request: Add configurable max clipboard size with `-max-size` flag

### Summary

This PR introduces a new `-max-size` flag that allows users to configure the maximum clipboard entry size to store, addressing issue #166.

### Changes

**`cliphist.go`:**
- Added new `-max-size` flag with default value `"5MB"` (preserves backward compatibility with
  the previous hardcoded `5*1e6` limit)
- Added `parseSize()` function to parse human-readable size strings into bytes
  - Supports decimal units: `KB`, `MB`, `GB` (base 1000)
  - Supports binary units: `KiB`, `MiB`, `GiB` (base 1024)
  - Supports raw byte values (e.g., `5000000`)
  - Case-insensitive parsing
  - Validates against negative values
- Modified `store()` function signature to accept `maxSize uint64` parameter
- Setting `-max-size 0` disables the size limit entirely

**`cliphist_test.go`:**
- Added `TestStoreMaxSize`: integration tests verifying store behavior with various size limits
- Added `TestParseSize`: unit tests covering all input formats and error cases

Tests written by GitHub Copilot Claude Opus 4.5.

### Usage Examples

```bash
# Default 5MB limit (unchanged behavior)
cliphist store

# Set limit to 10 MiB
cliphist -max-size 10MiB store

# Set limit to 1 GB
cliphist -max-size 1GB store

# Disable size limit
cliphist -max-size 0 store
```

### Backward Compatibility

The default value `"5MB"` parses to `5 * 1000 * 1000 = 5,000,000 bytes`, which is identical to the previous hardcoded value `5*1e6`.

### Closes #166