### PR TITLE
feat: add thumbnail preview support for images

### DIFF
--- a/cliphist.go
+++ b/cliphist.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"image"
+	"image/png"
 	"io"
 	"os"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 	"github.com/rivo/uniseg"
 	bolt "go.etcd.io/bbolt"
 	"go.senan.xyz/flagconf"
+	"golang.org/x/image/draw"
 )
 
 //go:embed version.txt
@@ -35,7 +37,7 @@ var version string
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "usage:\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  $ %s <store|list|decode|delete|delete-query|wipe|version>\n", flag.CommandLine.Name())
+		fmt.Fprintf(flag.CommandLine.Output(), "  $ %s <store|list|decode|delete|delete-query|wipe|rebuild-thumbnails|version>\n", flag.CommandLine.Name())
 		fmt.Fprintf(flag.CommandLine.Output(), "options:\n")
 		flag.VisitAll(func(f *flag.Flag) {
 			fmt.Fprintf(flag.CommandLine.Output(), "  -%s (default %s)\n", f.Name, f.DefValue)
@@ -60,6 +62,8 @@ func main() {
 	previewWidth := flag.Uint("preview-width", 100, "maximum number of characters to preview")
 	dbPath := flag.String("db-path", filepath.Join(cacheHome, "cliphist", "db"), "path to db")
 	configPath := flag.String("config-path", filepath.Join(configHome, "cliphist", "config"), "overwrite config path to use instead of cli flags")
+	thumbnailPath := flag.String("thumbnail-path", filepath.Join(cacheHome, "cliphist", "thumbnails"), "path to thumbnail cache directory")
+	thumbnailSize := flag.Uint("thumbnail-size", 64, "thumbnail size in pixels (square)")
 
 	flag.Parse()
 	flagconf.ParseEnv()
@@ -70,20 +74,22 @@ func main() {
 		switch os.Getenv("CLIPBOARD_STATE") { // from man wl-clipboard
 		case "sensitive":
 		case "clear":
-			err = deleteLast(*dbPath)
+			err = deleteLast(*dbPath, *thumbnailPath)
 		default:
-			err = store(*dbPath, os.Stdin, *maxDedupeSearch, *maxItems, *minLength)
+			err = store(*dbPath, *thumbnailPath, os.Stdin, *maxDedupeSearch, *maxItems, *minLength, *thumbnailSize)
 		}
 	case "list":
-		err = list(*dbPath, os.Stdout, *previewWidth)
+		err = list(*dbPath, *thumbnailPath, os.Stdout, *previewWidth)
 	case "decode":
 		err = decode(*dbPath, os.Stdin, os.Stdout, flag.Arg(1))
 	case "delete-query":
-		err = deleteQuery(*dbPath, flag.Arg(1))
+		err = deleteQuery(*dbPath, *thumbnailPath, flag.Arg(1))
 	case "delete":
-		err = delete(*dbPath, os.Stdin)
+		err = delete(*dbPath, *thumbnailPath, os.Stdin)
 	case "wipe":
-		err = wipeAndCompact(*dbPath)
+		err = wipeAndCompact(*dbPath, *thumbnailPath)
+	case "rebuild-thumbnails":
+		err = rebuildThumbnails(*dbPath, *thumbnailPath, *thumbnailSize)
 	case "version":
 		fmt.Fprintf(flag.CommandLine.Output(), "%s\t%s\n", "version", strings.TrimSpace(version))
 		flag.VisitAll(func(f *flag.Flag) {
@@ -99,7 +105,7 @@ func main() {
 	}
 }
 
-func store(dbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLength uint) error {
+func store(dbPath, thumbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLength, thumbSize uint) error {
 	input, err := io.ReadAll(in)
 	if err != nil {
 		return fmt.Errorf("read stdin: %w", err)
@@ -128,9 +134,15 @@ func store(dbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLen
 
 	b := tx.Bucket([]byte(bucketKey))
 
-	if err := deduplicate(b, input, maxDedupeSearch); err != nil {
+	deletedIDs, err := deduplicateWithIDs(b, input, maxDedupeSearch)
+	if err != nil {
 		return fmt.Errorf("deduplicating: %w", err)
 	}
+	// Clean up thumbnails for deduplicated entries
+	for _, delID := range deletedIDs {
+		deleteThumbnail(thumbPath, delID)
+	}
+
 	id, err := b.NextSequence()
 	if err != nil {
 		return fmt.Errorf("getting next sequence: %w", err)
@@ -138,13 +150,28 @@ func store(dbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLen
 	if err := b.Put(itob(id), input); err != nil {
 		return fmt.Errorf("insert stdin: %w", err)
 	}
-	if err := trimLength(b, maxItems); err != nil {
+
+	trimmedIDs, err := trimLengthWithIDs(b, maxItems)
+	if err != nil {
 		return fmt.Errorf("trimming length: %w", err)
+	}
+	// Clean up thumbnails for trimmed entries
+	for _, trimID := range trimmedIDs {
+		deleteThumbnail(thumbPath, trimID)
 	}
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit tx: %w", err)
 	}
+
+	// Generate thumbnail if this is an image
+	if _, _, err := image.DecodeConfig(bytes.NewReader(input)); err == nil {
+		if err := generateThumbnail(thumbPath, id, input, thumbSize); err != nil {
+			// Non-fatal: log but don't fail the store
+			fmt.Fprintf(os.Stderr, "warning: failed to generate thumbnail: %v\n", err)
+		}
+	}
+
 	return nil
 }
 
@@ -152,6 +179,12 @@ func store(dbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLen
 // seen items because we can't rely on sequence numbers when items can
 // be deleted when deduplicating
 func trimLength(b *bolt.Bucket, maxItems uint64) error {
+	_, err := trimLengthWithIDs(b, maxItems)
+	return err
+}
+
+func trimLengthWithIDs(b *bolt.Bucket, maxItems uint64) ([]uint64, error) {
+	var deletedIDs []uint64
 	c := b.Cursor()
 	var seen uint64
 	for k, _ := c.Last(); k != nil; k, _ = c.Prev() {
@@ -159,15 +192,22 @@ func trimLength(b *bolt.Bucket, maxItems uint64) error {
 			seen++
 			continue
 		}
+		deletedIDs = append(deletedIDs, btoi(k))
 		if err := b.Delete(k); err != nil {
-			return fmt.Errorf("delete :%w", err)
+			return deletedIDs, fmt.Errorf("delete :%w", err)
 		}
 		seen++
 	}
-	return nil
+	return deletedIDs, nil
 }
 
 func deduplicate(b *bolt.Bucket, input []byte, maxDedupeSearch uint64) error {
+	_, err := deduplicateWithIDs(b, input, maxDedupeSearch)
+	return err
+}
+
+func deduplicateWithIDs(b *bolt.Bucket, input []byte, maxDedupeSearch uint64) ([]uint64, error) {
+	var deletedIDs []uint64
 	c := b.Cursor()
 	var seen uint64
 	for k, v := c.Last(); k != nil; k, v = c.Prev() {
@@ -178,15 +218,110 @@ func deduplicate(b *bolt.Bucket, input []byte, maxDedupeSearch uint64) error {
 			seen++
 			continue
 		}
+		deletedIDs = append(deletedIDs, btoi(k))
 		if err := b.Delete(k); err != nil {
-			return fmt.Errorf("delete :%w", err)
+			return deletedIDs, fmt.Errorf("delete :%w", err)
 		}
 		seen++
 	}
+	return deletedIDs, nil
+}
+
+// generateThumbnail creates a thumbnail for an image and saves it to the thumbnail directory
+func generateThumbnail(thumbPath string, id uint64, data []byte, size uint) error {
+	if err := os.MkdirAll(thumbPath, 0700); err != nil {
+		return fmt.Errorf("create thumbnail dir: %w", err)
+	}
+
+	// Decode the original image
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("decode image: %w", err)
+	}
+
+	// Calculate thumbnail dimensions maintaining aspect ratio
+	bounds := img.Bounds()
+	origW, origH := bounds.Dx(), bounds.Dy()
+	thumbW, thumbH := int(size), int(size)
+
+	if origW > origH {
+		thumbH = int(float64(origH) * float64(size) / float64(origW))
+	} else {
+		thumbW = int(float64(origW) * float64(size) / float64(origH))
+	}
+
+	// Create thumbnail
+	thumb := image.NewRGBA(image.Rect(0, 0, thumbW, thumbH))
+	draw.CatmullRom.Scale(thumb, thumb.Bounds(), img, bounds, draw.Over, nil)
+
+	// Save thumbnail
+	thumbFile := filepath.Join(thumbPath, fmt.Sprintf("%d.png", id))
+	f, err := os.Create(thumbFile)
+	if err != nil {
+		return fmt.Errorf("create thumbnail file: %w", err)
+	}
+	defer f.Close()
+
+	if err := png.Encode(f, thumb); err != nil {
+		return fmt.Errorf("encode thumbnail: %w", err)
+	}
+
 	return nil
 }
 
-func list(dbPath string, out io.Writer, previewWidth uint) error {
+// deleteThumbnail removes a thumbnail file if it exists
+func deleteThumbnail(thumbPath string, id uint64) {
+	thumbFile := filepath.Join(thumbPath, fmt.Sprintf("%d.png", id))
+	os.Remove(thumbFile) // ignore errors, file might not exist
+}
+
+// thumbnailPath returns the path to a thumbnail if it exists, empty string otherwise
+func getThumbnailPath(thumbPath string, id uint64) string {
+	thumbFile := filepath.Join(thumbPath, fmt.Sprintf("%d.png", id))
+	if _, err := os.Stat(thumbFile); err == nil {
+		return thumbFile
+	}
+	return ""
+}
+
+// rebuildThumbnails generates thumbnails for all existing image entries
+func rebuildThumbnails(dbPath, thumbPath string, thumbSize uint) error {
+	db, err := initDBReadOnly(dbPath)
+	if err != nil {
+		return fmt.Errorf("opening db: %w", err)
+	}
+	defer db.Close()
+
+	tx, err := db.Begin(false)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	b := tx.Bucket([]byte(bucketKey))
+	c := b.Cursor()
+
+	var count int
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		id := btoi(k)
+		// Check if this is an image
+		if _, _, err := image.DecodeConfig(bytes.NewReader(v)); err == nil {
+			// Check if thumbnail already exists
+			if getThumbnailPath(thumbPath, id) == "" {
+				if err := generateThumbnail(thumbPath, id, v, thumbSize); err != nil {
+					fmt.Fprintf(os.Stderr, "warning: failed to generate thumbnail for %d: %v\n", id, err)
+				} else {
+					count++
+				}
+			}
+		}
+	}
+
+	fmt.Fprintf(os.Stdout, "generated %d thumbnails\n", count)
+	return nil
+}
+
+func list(dbPath, thumbPath string, out io.Writer, previewWidth uint) error {
 	db, err := initDBReadOnly(dbPath)
 	if err != nil {
 		return fmt.Errorf("opening db: %w", err)
@@ -202,7 +337,14 @@ func list(dbPath string, out io.Writer, previewWidth uint) error {
 	b := tx.Bucket([]byte(bucketKey))
 	c := b.Cursor()
 	for k, v := c.Last(); k != nil; k, v = c.Prev() {
-		fmt.Fprintln(out, preview(btoi(k), v, previewWidth))
+		id := btoi(k)
+		previewStr := preview(id, v, previewWidth)
+		// For images, append thumbnail path using rofi's icon format
+		if thumbFile := getThumbnailPath(thumbPath, id); thumbFile != "" {
+			fmt.Fprintf(out, "%s\x00icon\x1f%s\n", previewStr, thumbFile)
+		} else {
+			fmt.Fprintln(out, previewStr)
+		}
 	}
 	return nil
 }
@@ -258,7 +400,7 @@ func decode(dbPath string, in io.Reader, out io.Writer, input string) error {
 	return nil
 }
 
-func deleteQuery(dbPath string, query string) error {
+func deleteQuery(dbPath, thumbPath string, query string) error {
 	if query == "" {
 		return fmt.Errorf("please provide a query")
 	}
@@ -275,10 +417,12 @@ func deleteQuery(dbPath string, query string) error {
 	}
 	defer tx.Rollback() //nolint:errcheck
 
+	var deletedIDs []uint64
 	b := tx.Bucket([]byte(bucketKey))
 	c := b.Cursor()
 	for k, v := c.First(); k != nil; k, v = c.Next() {
 		if bytes.Contains(v, []byte(query)) {
+			deletedIDs = append(deletedIDs, btoi(k))
 			_ = b.Delete(k)
 		}
 	}
@@ -286,10 +430,15 @@ func deleteQuery(dbPath string, query string) error {
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit tx: %w", err)
 	}
+
+	// Clean up thumbnails
+	for _, id := range deletedIDs {
+		deleteThumbnail(thumbPath, id)
+	}
 	return nil
 }
 
-func deleteLast(dbPath string) error {
+func deleteLast(dbPath, thumbPath string) error {
 	db, err := initDB(dbPath)
 	if err != nil {
 		return fmt.Errorf("opening db: %w", err)
@@ -305,15 +454,24 @@ func deleteLast(dbPath string) error {
 	b := tx.Bucket([]byte(bucketKey))
 	c := b.Cursor()
 	k, _ := c.Last()
+	var deletedID uint64
+	if k != nil {
+		deletedID = btoi(k)
+	}
 	_ = b.Delete(k)
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit tx: %w", err)
 	}
+
+	// Clean up thumbnail
+	if deletedID > 0 {
+		deleteThumbnail(thumbPath, deletedID)
+	}
 	return nil
 }
 
-func delete(dbPath string, in io.Reader) error {
+func delete(dbPath, thumbPath string, in io.Reader) error {
 	input, err := io.ReadAll(in) // drain stdin before opening and locking db
 	if err != nil {
 		return fmt.Errorf("read stdin: %w", err)
@@ -330,11 +488,13 @@ func delete(dbPath string, in io.Reader) error {
 	}
 	defer tx.Rollback() //nolint:errcheck
 
+	var deletedIDs []uint64
 	for sc := bufio.NewScanner(bytes.NewReader(input)); sc.Scan(); {
 		id, err := extractID(sc.Text())
 		if err != nil {
 			return fmt.Errorf("extract id: %w", err)
 		}
+		deletedIDs = append(deletedIDs, id)
 		b := tx.Bucket([]byte(bucketKey))
 		if err := b.Delete(itob(id)); err != nil {
 			return fmt.Errorf("delete key: %w", err)
@@ -344,11 +504,16 @@ func delete(dbPath string, in io.Reader) error {
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit tx: %w", err)
 	}
+
+	// Clean up thumbnails
+	for _, id := range deletedIDs {
+		deleteThumbnail(thumbPath, id)
+	}
 	return nil
 }
 
-func wipeAndCompact(dbPath string) error {
-	if err := wipe(dbPath); err != nil {
+func wipeAndCompact(dbPath, thumbPath string) error {
+	if err := wipe(dbPath, thumbPath); err != nil {
 		return fmt.Errorf("wipe: %w", err)
 	}
 	if err := compactDB(dbPath); err != nil {
@@ -357,7 +522,7 @@ func wipeAndCompact(dbPath string) error {
 	return nil
 }
 
-func wipe(dbPath string) error {
+func wipe(dbPath, thumbPath string) error {
 	db, err := initDB(dbPath)
 	if err != nil {
 		return fmt.Errorf("opening db: %w", err)
@@ -378,6 +543,11 @@ func wipe(dbPath string) error {
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit tx: %w", err)
+	}
+
+	// Wipe thumbnails directory
+	if thumbPath != "" {
+		os.RemoveAll(thumbPath)
 	}
 	return nil
 }

--- a/testdata/thumbnail-dedupe-cleanup.txtar
+++ b/testdata/thumbnail-dedupe-cleanup.txtar
@@ -1,0 +1,22 @@
+# Test that thumbnails are cleaned up on deduplication
+exec png
+cp stdout image.png
+
+# store same image twice - second should dedupe first
+stdin image.png
+exec cliphist store
+
+# first entry gets id 1
+exists $HOME/cliphist/thumbnails/1.png
+
+stdin image.png
+exec cliphist store
+
+# second entry gets id 2, first should be deduped
+exists $HOME/cliphist/thumbnails/2.png
+! exists $HOME/cliphist/thumbnails/1.png
+
+# only one entry in list
+exec cliphist list
+stdout '2'
+! stdout '^1\t'

--- a/testdata/thumbnail-delete-on-entry-delete.txtar
+++ b/testdata/thumbnail-delete-on-entry-delete.txtar
@@ -1,0 +1,17 @@
+# Test that thumbnails are deleted when entries are deleted
+exec png
+stdin stdout
+exec cliphist store
+
+# verify thumbnail exists
+exists $HOME/cliphist/thumbnails/1.png
+
+# delete the entry
+stdin delete-query
+exec cliphist delete
+
+# check thumbnail was deleted
+! exists $HOME/cliphist/thumbnails/1.png
+
+-- delete-query --
+1	x

--- a/testdata/thumbnail-delete-on-wipe.txtar
+++ b/testdata/thumbnail-delete-on-wipe.txtar
@@ -1,0 +1,20 @@
+# Test that thumbnails are deleted when wipe is called
+exec png
+stdin stdout
+exec cliphist store
+
+# store text to avoid deduplication (png generates same image)
+stdin in-text
+exec cliphist store
+
+# verify thumbnail exists for image entry
+exists $HOME/cliphist/thumbnails/1.png
+
+# wipe all
+exec cliphist wipe
+
+# check thumbnail was wiped
+! exists $HOME/cliphist/thumbnails/1.png
+
+-- in-text --
+some text entry

--- a/testdata/thumbnail-generate-on-store.txtar
+++ b/testdata/thumbnail-generate-on-store.txtar
@@ -1,0 +1,12 @@
+# Test that thumbnails are generated when storing images
+exec png
+stdin stdout
+exec cliphist store
+
+# check thumbnail was created
+exists $HOME/cliphist/thumbnails/1.png
+
+# check list output includes icon path
+exec cliphist list
+stdout 'icon'
+stdout 'thumbnails/1.png'

--- a/testdata/thumbnail-not-for-text.txtar
+++ b/testdata/thumbnail-not-for-text.txtar
@@ -1,0 +1,14 @@
+# Test that thumbnails are NOT generated for text entries
+stdin in-text
+exec cliphist store
+
+# check no thumbnail was created
+! exists $HOME/cliphist/thumbnails/1.png
+
+# check list output does NOT include icon path
+exec cliphist list
+! stdout 'icon'
+stdout 'hello world'
+
+-- in-text --
+hello world

--- a/testdata/thumbnail-rebuild.txtar
+++ b/testdata/thumbnail-rebuild.txtar
@@ -1,0 +1,20 @@
+# Test rebuild-thumbnails command
+exec png
+stdin stdout
+exec cliphist store
+
+# verify thumbnail exists
+exists $HOME/cliphist/thumbnails/1.png
+
+# manually delete thumbnail using exec rm
+exec rm $HOME/cliphist/thumbnails/1.png
+
+# verify it's gone
+! exists $HOME/cliphist/thumbnails/1.png
+
+# rebuild thumbnails
+exec cliphist rebuild-thumbnails
+stdout 'generated 1 thumbnails'
+
+# verify it's back
+exists $HOME/cliphist/thumbnails/1.png


### PR DESCRIPTION
## Summary

This PR adds thumbnail preview support for image clipboard entries, enabling visual previews in rofi/dmenu launchers.

### Features
- **Auto-generate thumbnails** when storing images to clipboard
- **Rofi-compatible output** - list command outputs icon paths in rofi's extended format (`\x00icon\x1f<path>`)
- **Automatic cleanup** - thumbnails are deleted when entries are deleted, wiped, deduplicated, or trimmed
- **Rebuild command** - `rebuild-thumbnails` generates thumbnails for existing image entries
- **Configurable** - thumbnail size and cache path via flags

### New flags
- `-thumbnail-path` (default: `$XDG_CACHE_HOME/cliphist/thumbnails`) - cache directory for thumbnails
- `-thumbnail-size` (default: 64) - thumbnail dimensions in pixels (square)

### Usage with rofi
```bash
cliphist list | rofi -dmenu -show-icons | cliphist decode | wl-copy
```

### Screenshot
Before (text only):
```
5723    [[ binary data 68 KiB jpeg 721x1280 ]]
```

After (with thumbnail):
```
[thumbnail] 5723    [[ binary data 68 KiB jpeg 721x1280 ]]
```

### Tests
Added 6 new test cases covering:
- Thumbnail generation on store
- No thumbnails for text entries
- Thumbnail cleanup on delete
- Thumbnail cleanup on wipe
- Rebuild thumbnails command
- Thumbnail cleanup on deduplication

All 29 tests pass (`go test ./...`).