### PR TITLE
feat(contrib): compact db without wiping

### DIFF
--- a/cliphist.go
+++ b/cliphist.go
@@ -36,7 +36,7 @@ var version string
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "usage:\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  $ %s <store|list|decode|delete|delete-query|wipe|version>\n", flag.CommandLine.Name())
+		fmt.Fprintf(flag.CommandLine.Output(), "  $ %s <store|list|decode|delete|delete-query|wipe|compact|version>\n", flag.CommandLine.Name())
 		fmt.Fprintf(flag.CommandLine.Output(), "options:\n")
 		flag.VisitAll(func(f *flag.Flag) {
 			fmt.Fprintf(flag.CommandLine.Output(), "  -%s (default %s)\n", f.Name, f.DefValue)
@@ -92,6 +92,8 @@ func main() {
 		err = delete(*dbPath, os.Stdin)
 	case "wipe":
 		err = wipeAndCompact(*dbPath)
+	case "compact":
+		err = compactDB(*dbPath)
 	case "version":
 		fmt.Fprintf(flag.CommandLine.Output(), "%s\t%s\n", "version", strings.TrimSpace(version))
 		flag.VisitAll(func(f *flag.Flag) {

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,10 @@ Or else query manually:
 
 `$ cliphist wipe`.
 
+#### Compact database
+
+`$ cliphist compact`.
+
 ---
 
 ### Picker examples


### PR DESCRIPTION
I noticed that after manually removing some big entries using `cliphist delete` the database file does not shrink. I also saw a _recent_ commit (9fb195b66d8dfd5950416efdd47f7a62a8d32cd0) about compacting the database after a wipe, it seems logical to me however to allow the user to compact their database without wiping it. This shrunk my database from 61MiB to 8.6MiB.