### PR TITLE
feat: Add YAML configuration file support with database path customization

### DIFF
--- a/cliphist.go
+++ b/cliphist.go
@@ -27,10 +27,41 @@ import (
 	"github.com/rivo/uniseg"
 	bolt "go.etcd.io/bbolt"
 	"go.senan.xyz/flagconf"
+	"gopkg.in/yaml.v3"
 )
 
 //go:embed version.txt
 var version string
+
+type Config struct {
+    MaxItems         uint64 `yaml:"max-items"`
+    MaxDedupeSearch  uint64 `yaml:"max-dedupe-search"`
+    MinLength        uint   `yaml:"min-store-length"`
+    PreviewWidth     uint   `yaml:"preview-width"`
+    MaxStoreSize     string `yaml:"max-store-size"`
+    DBPath           string `yaml:"db-path"`
+}
+func parseConfigFile(configPath string) (*Config, error) {
+    // Check if config file exists
+    if _, err := os.Stat(configPath); os.IsNotExist(err) {
+        return nil, nil // No config file, that's fine
+    } else if err != nil {
+        return nil, fmt.Errorf("checking config file: %w", err)
+    }
+    
+    // Read and parse YAML file
+    data, err := os.ReadFile(configPath)
+    if err != nil {
+        return nil, fmt.Errorf("reading config file: %w", err)
+    }
+    
+    var cfg Config
+    if err := yaml.Unmarshal(data, &cfg); err != nil {
+        return nil, fmt.Errorf("parsing YAML config: %w", err)
+    }
+    
+    return &cfg, nil
+}
 
 //nolint:errcheck
 func main() {
@@ -54,14 +85,48 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	
+	configPath := flag.String("config-path", filepath.Join(configHome, "cliphist", "config.yml"), "overwrite config path to use instead of cli flags")
+	cfg, err := parseConfigFile(*configPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defaults := Config{
+		MaxItems:        750,
+		MaxDedupeSearch: 100,
+		MinLength:       0,
+		PreviewWidth:    100,
+		MaxStoreSize:    "5MB",
+		DBPath:          filepath.Join(cacheHome, "cliphist", "db"),
+	};
+	if cfg != nil {
+		if cfg.MaxItems != 0 {
+			defaults.MaxItems = cfg.MaxItems
+		}
+		if cfg.MaxDedupeSearch != 0 {
+			defaults.MaxDedupeSearch = cfg.MaxDedupeSearch
+		}
+		if cfg.MinLength != 0 {
+			defaults.MinLength = cfg.MinLength
+		}
+		if cfg.PreviewWidth != 0 {
+			defaults.PreviewWidth = cfg.PreviewWidth
+		}
+		if cfg.MaxStoreSize != "" {
+			defaults.MaxStoreSize = cfg.MaxStoreSize
+		}
+		if cfg.DBPath != "" {
+			defaults.DBPath = cfg.DBPath
+		}
+	}
 
-	maxItems := flag.Uint64("max-items", 750, "maximum number of items to store")
-	maxDedupeSearch := flag.Uint64("max-dedupe-search", 100, "maximum number of last items to look through when finding duplicates")
-	minLength := flag.Uint("min-store-length", 0, "minimum number of characters to store")
-	previewWidth := flag.Uint("preview-width", 100, "maximum number of characters to preview")
-	maxStoreSizeStr := flag.String("max-store-size", "5MB", "maximum size of clipboard to store (e.g., 5MB, 10MiB, 1GB)")
-	dbPath := flag.String("db-path", filepath.Join(cacheHome, "cliphist", "db"), "path to db")
-	configPath := flag.String("config-path", filepath.Join(configHome, "cliphist", "config"), "overwrite config path to use instead of cli flags")
+	maxItems := flag.Uint64("max-items", defaults.MaxItems, "maximum number of items to store")
+	maxDedupeSearch := flag.Uint64("max-dedupe-search", defaults.MaxDedupeSearch, "maximum number of last items to look through when finding duplicates")
+	minLength := flag.Uint("min-store-length", defaults.MinLength, "minimum number of characters to store")
+	previewWidth := flag.Uint("preview-width", defaults.PreviewWidth, "maximum number of characters to preview")
+	maxStoreSizeStr := flag.String("max-store-size", defaults.MaxStoreSize, "maximum size of clipboard to store (e.g., 5MB, 10MiB, 1GB)")
+	dbPath := flag.String("db-path", defaults.DBPath, "path to db")
 
 	flag.Parse()
 	flagconf.ParseEnv()

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	go.etcd.io/bbolt v1.3.9
 	go.senan.xyz/flagconf v0.1.9
 	golang.org/x/image v0.21.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -16,4 +16,7 @@ golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/tools v0.24.0 h1:J1shsA93PJUEVaUSaay7UXAyE8aimq3GW0pjlolpa24=
 golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
This PR adds YAML-based configuration file support to cliphist, allowing users to persist their preferred settings and customize the database path without using command-line flags.

## Changes
- Added YAML configuration file parsing using `gopkg.in/yaml.v3`
- Created `Config` struct for type-safe configuration management
- Implemented configuration priority: defaults → config file → command-line flags → environment variables
- Added support for configuring all existing options via config file:
  - `db-path`: Custom database location
  - `max-items`: Maximum number of stored items
  - `max-dedupe-search`: Duplicate detection window
  - `min-store-length`: Minimum text length to store
  - `preview-width`: Preview character limit
  - `max-store-size`: Maximum clipboard content size

## Configuration Details
Config file is expected at `~/.config/cliphist/config.yml` by default (customizable via `-config-path` flag).

Example configuration:
```yaml
# Custom database location
db-path: ~/.local/share/cliphist.db

# Increase storage limit
max-items: 1000

# Show longer previews
preview-width: 150

# Only store meaningful content
min-store-length: 20