### PR TITLE
cli: add one‑line descriptions for each subcommand in --help

### DIFF
--- a/cliphist.go
+++ b/cliphist.go
@@ -35,9 +35,19 @@ var version string
 //nolint:errcheck
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "usage:\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  $ %s <store|list|decode|delete|delete-query|wipe|compact|version>\n", flag.CommandLine.Name())
-		fmt.Fprintf(flag.CommandLine.Output(), "options:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s <command> [arguments]\n", flag.CommandLine.Name())
+		fmt.Fprintf(flag.CommandLine.Output(), "\nCommands:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  store           read clipboard content from stdin and store it (deduplicates, respects size/length limits)\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  list            list all stored clipboard items with previews\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  decode [id]     decode and print the full content for the given ID (or read ID from stdin)\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  delete-query    delete all entries containing a substring (query argument required)\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  delete          delete entries by reading IDs from stdin (one per line)\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  wipe            remove all entries and compact the database\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  compact         compact the database to reclaim space without deleting entries\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  version         print version and current flag values\n")
+
+		fmt.Fprintf(flag.CommandLine.Output(), "\nOptions:\n")
 		flag.VisitAll(func(f *flag.Flag) {
 			fmt.Fprintf(flag.CommandLine.Output(), "  -%s (default %s)\n", f.Name, f.DefValue)
 			fmt.Fprintf(flag.CommandLine.Output(), "    %s\n", f.Usage)


### PR DESCRIPTION
## What does this PR do?
Improves the usability of the command line interface by extending the `--help` output with a clear, concise description for every subcommand (store, list, decode, delete-query, delete, wipe, compact, version).

## Why is this change useful?
Previously, the help text only showed the list of command names without any hint about what each one does. New users had to guess or refer to external documentation. With this change, running `cliphist --help` immediately explains the purpose of each command, making the tool more self‑documenting and beginner‑friendly.

The new output should be like this
```text
$ ./cliphist                                                                                                                                              
Usage:
  ./cliphist <command> [arguments]

Commands:
  store           read clipboard content from stdin and store it (deduplicates, respects size/length limits)
  list            list all stored clipboard items with previews
  decode [id]     decode and print the full content for the given ID (or read ID from stdin)
  delete-query    delete all entries containing a substring (query argument required)
  delete          delete entries by reading IDs from stdin (one per line)
  wipe            remove all entries and compact the database
  compact         compact the database to reclaim space without deleting entries
  version         print version and current flag values

Options:
  -config-path (default /home/pxlman/.config/cliphist/config)
    overwrite config path to use instead of cli flags
  -db-path (default /home/pxlman/.cache/cliphist/db)
    path to db
  -max-dedupe-search (default 100)
    maximum number of last items to look through when finding duplicates
  -max-items (default 750)
    maximum number of items to store
  -max-store-size (default 5MB)
    maximum size of clipboard to store (e.g., 5MB, 10MiB, 1GB)
  -min-store-length (default 0)
    minimum number of characters to store
  -preview-width (default 100)
    maximum number of characters to preview
```