### PR TITLE
feat: add timestamp and mimetype metadata storage

### DIFF
--- a/cliphist.go
+++ b/cliphist.go
@@ -36,7 +36,7 @@ var version string
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "usage:\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  $ %s <store|list|decode|delete|delete-query|wipe|compact|version>\n", flag.CommandLine.Name())
+		fmt.Fprintf(flag.CommandLine.Output(), "  $ %s <store|list|decode|timestamp|mimetype|delete|delete-query|wipe|compact|version>\n", flag.CommandLine.Name())
 		fmt.Fprintf(flag.CommandLine.Output(), "options:\n")
 		flag.VisitAll(func(f *flag.Flag) {
 			fmt.Fprintf(flag.CommandLine.Output(), "  -%s (default %s)\n", f.Name, f.DefValue)
@@ -86,6 +86,10 @@ func main() {
 		err = list(*dbPath, os.Stdout, *previewWidth)
 	case "decode":
 		err = decode(*dbPath, os.Stdin, os.Stdout, flag.Arg(1))
+	case "timestamp":
+		err = timestamp(*dbPath, os.Stdin, os.Stdout, flag.Arg(1))
+	case "mimetype":
+		err = mimetype(*dbPath, os.Stdin, os.Stdout, flag.Arg(1))
 	case "delete-query":
 		err = deleteQuery(*dbPath, flag.Arg(1))
 	case "delete":
@@ -137,8 +141,9 @@ func store(dbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLen
 	defer tx.Rollback() //nolint:errcheck
 
 	b := tx.Bucket([]byte(bucketKey))
+	mb := tx.Bucket([]byte(metaBucketKey))
 
-	if err := deduplicate(b, input, maxDedupeSearch); err != nil {
+	if err := deduplicate(b, mb, input, maxDedupeSearch); err != nil {
 		return fmt.Errorf("deduplicating: %w", err)
 	}
 	id, err := b.NextSequence()
@@ -148,7 +153,14 @@ func store(dbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLen
 	if err := b.Put(itob(id), input); err != nil {
 		return fmt.Errorf("insert stdin: %w", err)
 	}
-	if err := trimLength(b, maxItems); err != nil {
+
+	_, _, decodeErr := image.DecodeConfig(bytes.NewReader(input))
+	meta := encodeMeta(time.Now().Unix(), decodeErr == nil)
+	if err := mb.Put(itob(id), meta); err != nil {
+		return fmt.Errorf("insert metadata: %w", err)
+	}
+
+	if err := trimLength(b, mb, maxItems); err != nil {
 		return fmt.Errorf("trimming length: %w", err)
 	}
 
@@ -161,7 +173,7 @@ func store(dbPath string, in io.Reader, maxDedupeSearch, maxItems uint64, minLen
 // trim the store's size to a number of max items. manually counting
 // seen items because we can't rely on sequence numbers when items can
 // be deleted when deduplicating
-func trimLength(b *bolt.Bucket, maxItems uint64) error {
+func trimLength(b *bolt.Bucket, mb *bolt.Bucket, maxItems uint64) error {
 	c := b.Cursor()
 	var seen uint64
 	for k, _ := c.Last(); k != nil; k, _ = c.Prev() {
@@ -172,12 +184,15 @@ func trimLength(b *bolt.Bucket, maxItems uint64) error {
 		if err := b.Delete(k); err != nil {
 			return fmt.Errorf("delete :%w", err)
 		}
+		if err := mb.Delete(k); err != nil {
+			return fmt.Errorf("delete meta: %w", err)
+		}
 		seen++
 	}
 	return nil
 }
 
-func deduplicate(b *bolt.Bucket, input []byte, maxDedupeSearch uint64) error {
+func deduplicate(b *bolt.Bucket, mb *bolt.Bucket, input []byte, maxDedupeSearch uint64) error {
 	c := b.Cursor()
 	var seen uint64
 	for k, v := c.Last(); k != nil; k, v = c.Prev() {
@@ -190,6 +205,9 @@ func deduplicate(b *bolt.Bucket, input []byte, maxDedupeSearch uint64) error {
 		}
 		if err := b.Delete(k); err != nil {
 			return fmt.Errorf("delete :%w", err)
+		}
+		if err := mb.Delete(k); err != nil {
+			return fmt.Errorf("delete meta: %w", err)
 		}
 		seen++
 	}
@@ -268,6 +286,95 @@ func decode(dbPath string, in io.Reader, out io.Writer, input string) error {
 	return nil
 }
 
+func timestamp(dbPath string, in io.Reader, out io.Writer, input string) error {
+	if input == "" {
+		inp, err := io.ReadAll(in)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+		input = string(inp)
+	}
+	id, err := extractID(input)
+	if err != nil {
+		return fmt.Errorf("extracting id: %w", err)
+	}
+
+	db, err := initDBReadOnly(dbPath)
+	if err != nil {
+		return fmt.Errorf("opening db: %w", err)
+	}
+	defer db.Close()
+
+	tx, err := db.Begin(false)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	mb := tx.Bucket([]byte(metaBucketKey))
+	raw := mb.Get(itob(id))
+	if raw == nil {
+		return fmt.Errorf("metadata for id %d not found", id)
+	}
+
+	ts, _ := decodeMeta(raw)
+
+	if _, err := fmt.Fprintln(out, ts); err != nil {
+		return fmt.Errorf("writing out: %w", err)
+	}
+	return nil
+}
+
+func mimetype(dbPath string, in io.Reader, out io.Writer, input string) error {
+	if input == "" {
+		inp, err := io.ReadAll(in)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+		input = string(inp)
+	}
+	id, err := extractID(input)
+	if err != nil {
+		return fmt.Errorf("extracting id: %w", err)
+	}
+
+	db, err := initDBReadOnly(dbPath)
+	if err != nil {
+		return fmt.Errorf("opening db: %w", err)
+	}
+	defer db.Close()
+
+	tx, err := db.Begin(false)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	mb := tx.Bucket([]byte(metaBucketKey))
+	var mt bool
+	if raw := mb.Get(itob(id)); raw != nil {
+		_, mt = decodeMeta(raw)
+	} else {
+		// Fallback to image decoding
+		b := tx.Bucket([]byte(bucketKey))
+		v := b.Get(itob(id))
+		if v == nil {
+			return fmt.Errorf("id %d not found", id)
+		}
+		_, _, derr := image.DecodeConfig(bytes.NewReader(v))
+		mt = derr == nil
+	}
+
+	result := "text"
+	if mt {
+		result = "binary"
+	}
+	if _, err := fmt.Fprintln(out, result); err != nil {
+		return fmt.Errorf("writing out: %w", err)
+	}
+	return nil
+}
+
 func deleteQuery(dbPath string, query string) error {
 	if query == "" {
 		return fmt.Errorf("please provide a query")
@@ -286,10 +393,12 @@ func deleteQuery(dbPath string, query string) error {
 	defer tx.Rollback() //nolint:errcheck
 
 	b := tx.Bucket([]byte(bucketKey))
+	mb := tx.Bucket([]byte(metaBucketKey))
 	c := b.Cursor()
 	for k, v := c.First(); k != nil; k, v = c.Next() {
 		if bytes.Contains(v, []byte(query)) {
 			_ = b.Delete(k)
+			_ = mb.Delete(k)
 		}
 	}
 
@@ -313,9 +422,11 @@ func deleteLast(dbPath string) error {
 	defer tx.Rollback() //nolint:errcheck
 
 	b := tx.Bucket([]byte(bucketKey))
+	mb := tx.Bucket([]byte(metaBucketKey))
 	c := b.Cursor()
 	k, _ := c.Last()
 	_ = b.Delete(k)
+	_ = mb.Delete(k)
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit tx: %w", err)
@@ -346,8 +457,12 @@ func delete(dbPath string, in io.Reader) error {
 			return fmt.Errorf("extract id: %w", err)
 		}
 		b := tx.Bucket([]byte(bucketKey))
+		mb := tx.Bucket([]byte(metaBucketKey))
 		if err := b.Delete(itob(id)); err != nil {
 			return fmt.Errorf("delete key: %w", err)
+		}
+		if err := mb.Delete(itob(id)); err != nil {
+			return fmt.Errorf("delete meta key: %w", err)
 		}
 	}
 
@@ -381,9 +496,11 @@ func wipe(dbPath string) error {
 	defer tx.Rollback() //nolint:errcheck
 
 	b := tx.Bucket([]byte(bucketKey))
+	mb := tx.Bucket([]byte(metaBucketKey))
 	c := b.Cursor()
 	for k, _ := c.First(); k != nil; k, _ = c.Next() {
 		_ = b.Delete(k)
+		_ = mb.Delete(k)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -393,6 +510,7 @@ func wipe(dbPath string) error {
 }
 
 const bucketKey = "b"
+const metaBucketKey = "m"
 
 func initDB(path string) (*bolt.DB, error)         { return initDBOption(path, false) }
 func initDBReadOnly(path string) (*bolt.DB, error) { return initDBOption(path, true) }
@@ -420,7 +538,10 @@ func initDBOption(path string, ro bool) (*bolt.DB, error) {
 		return db, nil
 	}
 	err = db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucketIfNotExists([]byte(bucketKey))
+		if _, err := tx.CreateBucketIfNotExists([]byte(bucketKey)); err != nil {
+			return err
+		}
+		_, err := tx.CreateBucketIfNotExists([]byte(metaBucketKey))
 		return err
 	})
 	if err != nil {
@@ -563,4 +684,20 @@ func parseSize(s string) (uint64, error) {
 		return 0, fmt.Errorf("invalid size: %w", err)
 	}
 	return num, nil
+}
+
+func encodeMeta(timestamp int64, mimetype bool) []byte {
+	buf := make([]byte, 9)
+	if mimetype {
+		buf[0] = 1
+	}
+
+	binary.BigEndian.PutUint64(buf[1:], uint64(timestamp))
+	return buf
+}
+
+func decodeMeta(raw []byte) (timestamp int64, mimetype bool) {
+	mimetype = raw[0] == 1
+	timestamp = int64(binary.BigEndian.Uint64(raw[1:]))
+	return
 }

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ Or else query manually:
 
 `cliphist timestamp` and `cliphist mimetype` accept the same `<id>\t<preview>`
 input as `decode`, and return the item's unix timestamp or content type
-(`text`/`image`) respectively.
+(`text`/`binary`) respectively.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,12 @@ Or else query manually:
 
 `$ cliphist compact`.
 
+#### Query item metadata
+
+`cliphist timestamp` and `cliphist mimetype` accept the same `<id>\t<preview>`
+input as `decode`, and return the item's unix timestamp or content type
+(`text`/`image`) respectively.
+
 ---
 
 ### Picker examples


### PR DESCRIPTION
## Changes
Added a second bucket to hold item metadata, specifically the timestamp and mimetype, and the subcommands to access the data.

The bucket is keyed identically to the main one and holds a 9-byte value, with the first byte representing the mimetype, and the remaining 8 are for the unix timestamp. `store` now calls the `image.DecodeConfig` to detect the mimetype.

`mimetype` and `timestamp` behave like `decode`, just outputting the 'text'/'binary' for the mimetype and a unix timestamp for the timestamp instead

The `list`/`preview`/`decode` are untouched and existing databases are handled gracefully. `mimetype` falls back to the `image.DecodeConfig` if the entry does not have metadata. `timestamp`, if the entry does not have metadata, outputs an error message like in the case with `decode`, if it fails to find the id.

## Why
I was building my quickshell config and i really wanted to have timestamps. After looking through issues and prs i decided to make a pr myself and try to follow the idea (https://github.com/sentriz/cliphist/pull/183#issuecomment-5069044894). This should close #167, help with #183 and #100, and provide an actual way of tracking what is an image and what is text(or the mimetypes in general, if somebody wants to go further), instead of having to rely on parsing the entry/binary output to check for type (makes it easier and more reliable for the user to implement image previews in menus for example).

## Further improvements/suggestions

- With the tracking of the mimetype at `store`, the use of the `image.DecodeConfig` in `preview` thats being called in `list` for each entry can be replaced by the mimetype check, and actually call `image.DecodeConfig` in the case when the entry does not have metadata to account for database entries that were created prior to new additions (as suggested by https://github.com/sentriz/cliphist/pull/183#issuecomment-5077915462).
- Also, maybe the new use of `image.DecodeConfig` in `store` could be replaced to something more lightweight, the only idea i have for that at the moment is adding a type flag to the `store` subcommand and checking that (something like `wl-paste --type image --watch cliphist store --type image`).
- Right now the `mimetype` in the bucket is just a bool flag(not image/image), but in theory could be expanded, (with the use of enums to be more manageable i guess) since it reserves a full byte. On the other end, a full byte could be saved in theory if it would be stored inside the 8-byte timestamp at the cost of readability and complexity of the code.
- It probably would be better to add a subcommand or a flag for `list` to show all info about the entry in one command

## Additional notes
I did not do extensive testing, go test ./ passes, entries from mixed db(pre-patch + post-patch entries) work like expected.

I am new to everything related to linux and its my first time touching go, and first time making a pull request. Making this has been a very interesting experience, learned a lot. I hope this pr is going to be useful to you, and I`m looking forward to your feedback.